### PR TITLE
Improve items

### DIFF
--- a/components/ListItem.tsx
+++ b/components/ListItem.tsx
@@ -9,13 +9,16 @@ type Props = {
   isSignIn: boolean;
 };
 
-export function ListItem({ item: { url, title, date }, isSignIn }: Props) {
-  const days = countDaysBetween(new Date(), new Date(date));
+export function ListItem(
+  { item: { url, title, date, dateISO }, isSignIn }: Props,
+) {
+  // TODO: Use only dateISO after migration
+  const days = countDaysBetween(new Date(), new Date(dateISO || date));
   const bgColor = days > config.remindIn + 1 ? "bg-gray-200" : "";
 
   return (
     <li
-      id={url}
+      id={dateISO || url}
       class={`border rounded p-2 my-1.5 flex justify-between ${bgColor}`}
     >
       <div>
@@ -29,13 +32,13 @@ export function ListItem({ item: { url, title, date }, isSignIn }: Props) {
             {title || url}
           </a>
         </h3>
-        <time class="text-gray-500" dateTime={date}>
-          {date}
+        <time class="text-gray-500" dateTime={dateISO || date}>
+          {dateISO || date}
         </time>
       </div>
       {isSignIn && (
         <div>
-          <DeleteButton item={{ date, url }} />
+          <DeleteButton item={{ date, url, dateISO }} />
         </div>
       )}
     </li>

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -5,11 +5,12 @@
 import * as $0 from "./routes/_middleware.ts";
 import * as $1 from "./routes/api/logins.ts";
 import * as $2 from "./routes/api/search-items.ts";
-import * as $3 from "./routes/index.tsx";
-import * as $4 from "./routes/items.ts";
-import * as $5 from "./routes/items/[date].tsx";
-import * as $6 from "./routes/login.tsx";
-import * as $7 from "./routes/logout.ts";
+import * as $3 from "./routes/api/update-item-format.ts";
+import * as $4 from "./routes/index.tsx";
+import * as $5 from "./routes/items.ts";
+import * as $6 from "./routes/items/[date].tsx";
+import * as $7 from "./routes/login.tsx";
+import * as $8 from "./routes/logout.ts";
 import * as $$0 from "./islands/DeleteButton.tsx";
 
 const manifest = {
@@ -17,11 +18,12 @@ const manifest = {
     "./routes/_middleware.ts": $0,
     "./routes/api/logins.ts": $1,
     "./routes/api/search-items.ts": $2,
-    "./routes/index.tsx": $3,
-    "./routes/items.ts": $4,
-    "./routes/items/[date].tsx": $5,
-    "./routes/login.tsx": $6,
-    "./routes/logout.ts": $7,
+    "./routes/api/update-item-format.ts": $3,
+    "./routes/index.tsx": $4,
+    "./routes/items.ts": $5,
+    "./routes/items/[date].tsx": $6,
+    "./routes/login.tsx": $7,
+    "./routes/logout.ts": $8,
   },
   islands: {
     "./islands/DeleteButton.tsx": $$0,

--- a/islands/DeleteButton.tsx
+++ b/islands/DeleteButton.tsx
@@ -4,28 +4,32 @@ import IconTrash from "tabler_icons_tsx/tsx/trash.tsx";
 import { type Item } from "@/lib/db/items.kv.ts";
 
 type Props = {
-  item: Pick<Item, "date" | "url">;
+  // Remove `url` after migration
+  item: Pick<Item, "date" | "dateISO" | "url">;
 };
 
-export function DeleteButton({ item: { date, url } }: Props) {
+export function DeleteButton({ item: { date, dateISO, url } }: Props) {
   const handleClick: JSX.MouseEventHandler<HTMLButtonElement> = async () => {
     if (!confirm("Are you sure to delete this?")) {
       return;
     }
 
-    const res = await fetch(new URL(`/items/${date}`, location.origin), {
-      method: "DELETE",
-      headers: {
-        "Content-Type": "application/json",
+    const res = await fetch(
+      new URL(`/items/${dateISO || date}`, location.origin),
+      {
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ url }),
       },
-      body: JSON.stringify({ url }),
-    });
+    );
 
     if (!res.ok || res.status >= 400) {
       return alert("Something wrong happens");
     }
 
-    const li = document.getElementById(url);
+    const li = document.getElementById(dateISO || url);
     if (li) li.remove();
   };
 

--- a/lib/db/items.kv.ts
+++ b/lib/db/items.kv.ts
@@ -2,19 +2,31 @@ import { defineKVFunc, list } from "@/lib/db/kv.ts";
 
 export type Item = {
   date: string; // YYYY-MM-DD
+  dateISO: string;
   url: string;
   title: string;
 };
 
 const PREFIX = "items";
 
-export const createItem = defineKVFunc<Item, void>(async (kv, data) => {
-  await kv.set([PREFIX, data.date, data.url], data);
+export const createItem = defineKVFunc<
+  Pick<Item, "url" | "title"> & { date: Date },
+  void
+>(async (kv, data) => {
+  const dateISO = data.date.toISOString();
+  const date = dateISO.slice(0, 10);
+  await kv.set([PREFIX, date, dateISO], { ...data, date, dateISO });
 });
 
-export const deleteItem = defineKVFunc<Pick<Item, "date" | "url">, void>(
+export const deleteItemLegacy = defineKVFunc<Pick<Item, "date" | "url">, void>(
   async (kv, data) => {
     await kv.delete([PREFIX, data.date, data.url]);
+  },
+);
+
+export const deleteItem = defineKVFunc<Pick<Item, "date" | "dateISO">, void>(
+  async (kv, data) => {
+    await kv.delete([PREFIX, data.date, data.dateISO]);
   },
 );
 

--- a/lib/db/kv.ts
+++ b/lib/db/kv.ts
@@ -4,9 +4,8 @@ type KVFunc<T> = (kv: KV) => Promise<T>;
 
 export const kv = await Deno.openKv(Deno.env.get("KV_PATH"));
 
-export async function runKV<T>(fn: (kv: KV) => Promise<T>): Promise<T> {
-  const ret = await fn(kv);
-  return ret;
+export function runKV<T>(fn: (kv: KV) => Promise<T>): Promise<T> {
+  return fn(kv);
 }
 
 export function defineKVFunc<Arg, ReturnValue>(

--- a/routes/api/update-item-format.ts
+++ b/routes/api/update-item-format.ts
@@ -1,0 +1,26 @@
+import { type Handlers } from "$fresh/server.ts";
+
+import { config } from "@/lib/config.ts";
+import { runKV } from "@/lib/db/kv.ts";
+import { updateItemFormat } from "@/lib/db/items.kv.ts";
+
+function validAuth(auth: string | null): boolean {
+  if (!auth) return false;
+
+  const [_, apiKey] = auth.split("Bearer ");
+  return !!apiKey && apiKey === config.api.key;
+}
+
+export const handler: Handlers = {
+  async POST(req) {
+    if (!validAuth(req.headers.get("Authorization"))) {
+      return new Response(null, { status: 404 });
+    }
+
+    await runKV(updateItemFormat());
+
+    return new Response(JSON.stringify({ message: "Success" }), {
+      status: 200,
+    });
+  },
+};

--- a/routes/items.ts
+++ b/routes/items.ts
@@ -31,9 +31,7 @@ export const handler: Handlers<unknown, State> = {
     assert(typeof url === "string");
 
     const title = await fetchTitle(url);
-    const date = new Date().toISOString().slice(0, 10);
-
-    await runKV(createItem({ date, url, title }));
+    await runKV(createItem({ date: new Date(), url, title }));
 
     return new Response(null, { headers: { location: "/" }, status: 302 });
   },

--- a/routes/items/[date].tsx
+++ b/routes/items/[date].tsx
@@ -2,7 +2,7 @@ import { type Handlers } from "$fresh/server.ts";
 import { assert } from "$std/assert/mod.ts";
 
 import { type State } from "@/lib/context.ts";
-import { deleteItem } from "@/lib/db/items.kv.ts";
+import { deleteItem, deleteItemLegacy } from "@/lib/db/items.kv.ts";
 import { runKV } from "@/lib/db/kv.ts";
 
 export const handler: Handlers<unknown, State> = {
@@ -15,12 +15,23 @@ export const handler: Handlers<unknown, State> = {
     assert(typeof json.url == "string" && !!json.url);
     assert(!!ctx.params.date);
 
-    await runKV(
-      deleteItem({
-        date: ctx.params.date,
-        url: json.url,
-      }),
-    );
+    const { date: dateISO } = ctx.params;
+
+    if (dateISO.length === 10) {
+      await runKV(
+        deleteItemLegacy({
+          date: dateISO,
+          url: json.url,
+        }),
+      );
+    } else {
+      await runKV(
+        deleteItem({
+          date: dateISO.slice(0, 10),
+          dateISO,
+        }),
+      );
+    }
 
     return new Response(null, { status: 204 });
   },


### PR DESCRIPTION
This p-r aims to control more precise time for `items`.

## TODO after deploy

- [ ] data migration: `POST /api/update-item-format`
- [ ] remove backward compatibility code
