### PR TITLE
chore: load from .env not .envrc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+API_KEY="xxx"

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,1 +1,0 @@
-export API_KEY="xxx"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 _fresh/
 
-.envrc
+.env

--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 - simple bookmark app
 - remind me what I read before
 
-## Dependency
-
-- direnv
-
 ## Usage
 
 Start the project:

--- a/deno.lock
+++ b/deno.lock
@@ -273,6 +273,8 @@
     "https://deno.land/std@0.201.0/datetime/parse.ts": "b59f583e7fe5ef2105c6dd4a74825670c9f4e1e35462c047c6f0a207b5653aac",
     "https://deno.land/std@0.201.0/datetime/to_imf.ts": "8f9c0af8b167031ffe2e03da01a12a3b0672cc7562f89c61942a0ab0129771b2",
     "https://deno.land/std@0.201.0/datetime/week_of_year.ts": "4f327c5656959759fac0a0bb642cfd6a0a64440e5a876ab218edbee006d98d20",
+    "https://deno.land/std@0.201.0/dotenv/load.ts": "0636983549b98f29ab75c9a22a42d9723f0a389ece5498fe971e7bb2556a12e2",
+    "https://deno.land/std@0.201.0/dotenv/mod.ts": "1da8c6d0e7f7d8a5c2b19400b763bc11739df24acec235dda7ea2cfd3d300057",
     "https://deno.land/std@0.201.0/fmt/colors.ts": "87544aa2bc91087bb37f9c077970c85bfb041b48e4c37356129d7b450a415b6f",
     "https://deno.land/std@0.201.0/http/cookie.ts": "d965ca071376732663738861bc5dd524df5d8ee69658de40dbfe41c39e379aa4",
     "https://deno.land/x/code_block_writer@11.0.3/mod.ts": "2c3448060e47c9d08604c8f40dee34343f553f33edcdfebbf648442be33205e5",

--- a/dev.ts
+++ b/dev.ts
@@ -2,4 +2,6 @@
 
 import dev from "$fresh/dev.ts";
 
+import "$std/dotenv/load.ts";
+
 await dev(import.meta.url, "./main.ts");

--- a/main.ts
+++ b/main.ts
@@ -12,6 +12,5 @@ import twindPlugin from "$fresh/plugins/twindv1.ts";
 import twindConfig from "./twind.config.ts";
 
 await start(manifest, {
-  port: Number(Deno.env.get("PORT") || "8000"),
   plugins: [twindPlugin(twindConfig)],
 });


### PR DESCRIPTION
You can pass `PORT` as default behaviour: https://fresh.deno.dev/docs/getting-started/running-locally 