### PR TITLE
fix(cron): make minute explicit

### DIFF
--- a/cron.ts
+++ b/cron.ts
@@ -1,4 +1,4 @@
 import { runReminder } from "@/lib/cron/reminder.ts";
 
 // 08:00 AM (JST)
-Deno.cron("Remind older bookmarks", { hour: 23 }, runReminder);
+Deno.cron("Remind older bookmarks", { minute: 0, hour: 23 }, runReminder);


### PR DESCRIPTION
The former code was equal to `* 23 * * *`